### PR TITLE
Add "Application.ReadWrite.All" to scope check

### DIFF
--- a/src/Build-AzureADAppConsentGrantReport.ps1
+++ b/src/Build-AzureADAppConsentGrantReport.ps1
@@ -51,7 +51,7 @@ function Build-AzureADAppConsentGrantReport {
         function checkMSGraphConnection {
 
 
-        $apiPermissionScopes = @("Application.Read.All")
+        $apiPermissionScopes = @("Application.Read.All", "Application.ReadWrite.All")
  
         if ($null -eq (Get-MgContext) -or $null -eq (Get-MgContext).Scopes) {
             Write-Error "Please Connect to MS Graph API with the Connect-mgGraph cmdlet from the Microsoft.Graph.Authentication module first before calling functions! Application.Read.All is the recommended scope. Sign in with 'Connect-MgGraph -Scopes Application.Read.All'" -ErrorAction Stop


### PR DESCRIPTION
The consent request adds the Application.ReadWrite.All scope yet the script "Build-AzureADAppConsentGrantReport.ps1" errors on anything other than Application.Read.All. This leaves the original Read and adds ReadWrite to the array so it no longer errors.